### PR TITLE
Allow to pass additional arguments.

### DIFF
--- a/notify_send.pl
+++ b/notify_send.pl
@@ -116,11 +116,12 @@ sub new_notification {
 
 	# run system command
 	if($send eq 'true') {
-		my ($command,$args) = split(/ /,$settings{'command'},2);
-		$args =~ s/\$type/$type/g;
-		$args =~ s/\$name/$name/g;
-		$args =~ s/\$message/$message/g;
-		system($command, $args);
+		my @args = split(/ /,$settings{'command'});
+		my $command = shift(@args);
+		s/\$type/$type/g for @args;
+		s/\$name/$name/g for @args;
+		s/\$message/$message/g for @args;
+		system($command, @args);
 	}
 
 	return weechat::WEECHAT_RC_OK;


### PR DESCRIPTION
I would like to be able to pass additional arguments to notify-send, for example to control the timeout, or to specify a different icon, and to be able to pass a title as well as a message to the notification.

```
/set plugins.var.perl.notify_send.command "notify-send --expire-time=60000 --icon=network $name $message"
```

This pull request still splits the string on space boundaries, so it only supports long arguments (eg '--expire-time=60000' rather than '-t 60000').